### PR TITLE
Remove wrong line break

### DIFF
--- a/charts/hedgedoc/values.yaml
+++ b/charts/hedgedoc/values.yaml
@@ -6,8 +6,7 @@ image:
   repository: ghcr.io/linuxserver/hedgedoc
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.7.2-ls9
-"
+  tag: "1.7.2-ls9"
 secret: {}
 # DB_USER: "hedgedoc"
 # DB_PASS: "<secret password>"


### PR DESCRIPTION
I think you've missed that one, leading to `Pod "hedgedoc-[…]" is invalid: spec.containers[0].image: Invalid value: "ghcr.io/linuxserver/hedgedoc:1.7.2-ls9 ": must not have leading or trailing whitespace;`.

Thanks a lot for creating this Chart! :heart: 

Cheers