### PR TITLE
fix(wikijs): add fsgroup 911 to pod security context

### DIFF
--- a/charts/wikijs/Chart.yaml
+++ b/charts/wikijs/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 appVersion: 2.5.170
-version: 0.1.11
+version: 0.2.0
 name: wikijs
 description: The most powerful and extensible open source Wiki software.
 type: application
@@ -25,7 +25,7 @@ maintainers:
     email: ncwilde43@gmail.com
 annotations:
   artifacthub.io/changes: |
-    - Bumped tag to 2.5.170-ls24
+    - Add pod security context for service user
   artifacthub.io/images: |
     - name: wikijs
       image: ghcr.io/linuxserver/wikijs:2.5.170-ls24

--- a/charts/wikijs/values.yaml
+++ b/charts/wikijs/values.yaml
@@ -11,8 +11,6 @@ secret: {}
 env:
   # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   TZ: "America/Los_Angeles"
-  # PUID: "1000"
-  # PGID: "1000"
 service:
   port:
     port: 3000
@@ -28,6 +26,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+podSecurityContext:
+  fsGroup: 911
 persistence:
   config:
     enabled: false


### PR DESCRIPTION
The WikiJS service in LinuxServer's container runs under a user `abc` (uid#911)
This change ensures we can write to the data mount.

It also removes the suggestion of modifying the PUID/GUID which shouldn't be necessary for the k8s context.

Fixes #22 