### PR TITLE
Fix mariadb not booting

### DIFF
--- a/charts/mariadb/templates/common.yaml
+++ b/charts/mariadb/templates/common.yaml
@@ -1,2 +1,31 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
 
+{{/* Append the configMap to the additionalVolumes */}}
+{{- define "mariadb.configmap.volume" -}}
+name: mariadb-settings
+configMap:
+  name: {{ template "common.names.fullname" . }}-config
+{{- end -}}
+
+{{- $volume := include "mariadb.configmap.volume" . | fromYaml -}}
+{{- if $volume -}}
+    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- end -}}
+
+{{/* Append the configMap volume to the additionalVolumeMounts */}}
+{{- define "mariadb.configmap.volumeMount" -}}
+name: mariadb-settings
+mountPath: /etc/mysql/conf.d/custom.cnf
+subPath: custom.cnf
+{{- end -}}
+
+{{- $volumeMount := include "mariadb.configmap.volumeMount" . | fromYaml -}}
+{{- if $volumeMount -}}
+    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
+    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
+{{- end -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/mariadb/templates/configmap.yaml
+++ b/charts/mariadb/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.names.fullname" . }}-config
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  custom.cnf: |
+    [mysqld]
+    expire_logs_days=7
+    skip_name_resolve
+    # Disabling symbolic-links is recommended to prevent assorted security risks
+    symbolic-links=0


### PR DESCRIPTION
This is an example fixed, based on how the k8s-at-home common chart handles mounting configmaps.

I've not tested it with your common chart, but with this example, you should be able to fix #19