### PR TITLE
fix common ingress template

### DIFF
--- a/charts/common/templates/classes/_ingress.tpl
+++ b/charts/common/templates/classes/_ingress.tpl
@@ -14,8 +14,6 @@ within the common library.
 {{- if hasKey $values "nameSuffix" -}}
   {{- $ingressName = printf "%v-%v" $ingressName $values.nameSuffix -}}
 {{ end -}}
-{{- $svcName := $values.serviceName | default (include "common.names.fullname" .) -}}
-{{- $svcPort := $values.servicePort | default $.Values.service.port.port -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -47,13 +45,13 @@ spec:
             pathType: {{ .pathType }}
             backend:
               {{- if ne $version "networking.k8s.io/v1" }}
-              serviceName: {{ $svcName }}
-              servicePort: {{ $svcPort }}
+              serviceName: {{ .backend.serviceName }}
+              servicePort: {{ .backend.servicePort }}
               {{- else }}
               service:
-                name: {{ $svcName }}
+                name: {{ .backend.serviceName }}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ .backend.servicePort  }}
               {{- end }}
           {{- end }}
   {{- end }}


### PR DESCRIPTION
```
ingress:
  enabled: true
  annotations: {
    kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
  }
  hosts:
    - host: testhost
      paths:
      - path: /
        pathType: Prefix
        backend:
          serviceName: service-a
          servicePort: 80
      - path: /api
        pathType: Prefix
        backend:
          serviceName: service-b
          servicePort: 80
```

For ingress configuration like the upper code, we need to parse each path and set up their backend `serviceName` and `servicePort`. We can not use app name as `serviceName` and app service port as `servicePort`.

