### PR TITLE
[common] Added support for 'envFrom' values section as defined in values.yaml

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for nicholaswilde's helm charts
 type: library
-version: 0.1.13
+version: 0.1.14
 keywords:
   - nicholaswilde
   - common

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -15,8 +15,11 @@ The main container included in the controller.
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if or .Values.env .Values.secret }}
+  {{- if or .Values.env .Values.secret .Values.envFrom }}
   envFrom:
+  {{- with .Values.envFrom }}
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.env }}
     - configMapRef:
         name: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
**Description of the change**

At the moment envFrom section defined in [values.yaml](https://github.com/nicholaswilde/helm-charts/blob/main/charts/common/values.yaml#L35) doesn't honor user configured secrets/configmaps.
This PR fixes it.

**Benefits**

Consumers can expose any arbitrary configmaps/secrets as env variables. It can be benefitial when used in combination with operators like [external-secrets](https://github.com/external-secrets/external-secrets/).